### PR TITLE
update libp2p, gx publish 1.0.2

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.1: QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr
+1.0.2: QmXXyj9Ugysn75Z62sFY8yo7cLi7waUd6wxR7eLN4x2BTA

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmSNJRX4uphb3Eyp69uYbpRVvgqjPxfjnJmjcdMWkDH5Pn",
+      "hash": "QmPd5qhppUqewTQMfStvNNCFtcxiWGsnE6Vs3va6788gsX",
       "name": "go-libp2p",
-      "version": "4.3.9"
+      "version": "5.0.12"
     },
     {
       "author": "multiformats",
@@ -25,6 +25,6 @@
   "license": "MIT/BSD",
   "name": "go-libp2p-gorpc",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }
 


### PR DESCRIPTION
Updating libp2p in deps to match version used by go-ipfs to eliminate dex import errors in ipfs-cluster