### PR TITLE
Feat: add context support to libp2p-gorpc

### DIFF
--- a/call.go
+++ b/call.go
@@ -80,7 +80,7 @@ func (call *Call) watchContextWithStream(s inet.Stream) {
 	case <-call.ctx.Done():
 		if !call.isFinished() { // context was cancelled not by us
 			logger.Debug("call context is done before finishing")
-			// Close() instead of Reset(). This let's the other
+			// Close() instead of Reset(). This lets the other
 			// write to the stream without printing errors to
 			// the console (graceful fail).
 			s.Close()

--- a/call.go
+++ b/call.go
@@ -15,8 +15,8 @@ type Call struct {
 	ctx    context.Context
 	cancel func()
 
-	finished   bool
 	finishedMu sync.RWMutex
+	finished   bool
 
 	Dest  peer.ID
 	SvcID ServiceID   // The name of the service and method to call.

--- a/call.go
+++ b/call.go
@@ -1,0 +1,91 @@
+package rpc
+
+import (
+	"context"
+	"sync"
+
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// Call represents an active RPC. Calls are used to indicate completion
+// of RPC requests and are returned within the provided channel in
+// the Go() functions.
+type Call struct {
+	ctx    context.Context
+	cancel func()
+
+	finished   bool
+	finishedMu sync.RWMutex
+
+	Dest  peer.ID
+	SvcID ServiceID   // The name of the service and method to call.
+	Args  interface{} // The argument to the function (*struct).
+	Reply interface{} // The reply from the function (*struct).
+	Error error       // After completion, the error status.
+	Done  chan *Call  // Strobes when call is complete.
+}
+
+func newCall(ctx context.Context, dest peer.ID, svcName, svcMethod string, args interface{}, reply interface{}, done chan *Call) *Call {
+	ctx2, cancel := context.WithCancel(ctx)
+	return &Call{
+		ctx:    ctx2,
+		cancel: cancel,
+		Dest:   dest,
+		SvcID:  ServiceID{svcName, svcMethod},
+		Args:   args,
+		Reply:  reply,
+		Error:  nil,
+		Done:   done,
+	}
+}
+
+// done places the completed call in the done channel.
+func (call *Call) done() {
+	call.finishedMu.Lock()
+	call.finished = true
+	call.finishedMu.Unlock()
+
+	select {
+	case call.Done <- call:
+		// ok
+	default:
+		logger.Debugf("discarding %s.%s call reply",
+			call.SvcID.Name, call.SvcID.Method)
+	}
+	call.cancel()
+}
+
+func (call *Call) doneWithError(err error) {
+	call.Error = err
+	call.done()
+}
+
+func (call *Call) isFinished() bool {
+	call.finishedMu.RLock()
+	defer call.finishedMu.RUnlock()
+	return call.finished
+}
+
+// watch context will wait for a context cancellation
+// and close the stream.
+func (call *Call) watchContextWithStream(s inet.Stream) {
+	select {
+	case <-call.ctx.Done():
+		if !call.isFinished() { // context was cancelled not by us
+			s.Reset()
+			call.doneWithError(call.ctx.Err())
+		}
+	}
+}
+
+// watch context will wait for a context cancellation
+// and close the stream.
+func (call *Call) watchContext() {
+	select {
+	case <-call.ctx.Done():
+		if !call.isFinished() { // context was cancelled not by us
+			call.doneWithError(call.ctx.Err())
+		}
+	}
+}

--- a/call.go
+++ b/call.go
@@ -73,18 +73,11 @@ func (call *Call) watchContextWithStream(s inet.Stream) {
 	select {
 	case <-call.ctx.Done():
 		if !call.isFinished() { // context was cancelled not by us
-			s.Reset()
-			call.doneWithError(call.ctx.Err())
-		}
-	}
-}
-
-// watch context will wait for a context cancellation
-// and close the stream.
-func (call *Call) watchContext() {
-	select {
-	case <-call.ctx.Done():
-		if !call.isFinished() { // context was cancelled not by us
+			logger.Debug("call context is done before finishing")
+			// Close() instead of Reset(). This let's the other
+			// write to the stream without printing errors to
+			// the console (graceful fail).
+			s.Close()
 			call.doneWithError(call.ctx.Err())
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -113,16 +113,11 @@ func (c *Client) makeCall(call *Call) {
 		if c.server == nil {
 			err := errors.New(
 				"Cannot make local calls: server not set")
-			logger.Error(err)
 			call.doneWithError(err)
 			return
 		}
 		err := c.server.Call(call)
-		call.Error = err
-		if err != nil {
-			logger.Error(err)
-		}
-		call.done()
+		call.doneWithError(err)
 		return
 	}
 
@@ -185,13 +180,13 @@ func receiveResponse(s *streamWrap, call *Call) {
 
 	defer call.done()
 	if e := resp.Error; e != "" {
-		call.Error = errors.New(e)
+		call.setError(errors.New(e))
 	}
 
 	// Even on error we sent the reply so it needs to be
 	// read
 	if err := s.dec.Decode(call.Reply); err != nil && err != io.EOF {
-		call.Error = err
+		call.setError(err)
 	}
 	return
 }

--- a/client.go
+++ b/client.go
@@ -55,12 +55,12 @@ func (c *Client) ID() peer.ID {
 // attempt to use the local configured Server when possible.
 func (c *Client) Call(dest peer.ID, svcName string, svcMethod string, args, reply interface{}) error {
 	ctx := context.Background()
-	return c.CallWithContext(ctx, dest, svcName, svcMethod, args, reply)
+	return c.CallContext(ctx, dest, svcName, svcMethod, args, reply)
 }
 
-// CallWithContext performs a Call() with a user provided context. This gives
+// CallContext performs a Call() with a user provided context. This gives
 // the user the possibility of cancelling the operation at any point.
-func (c *Client) CallWithContext(ctx context.Context, dest peer.ID, svcName, svcMethod string, args, reply interface{}) error {
+func (c *Client) CallContext(ctx context.Context, dest peer.ID, svcName, svcMethod string, args, reply interface{}) error {
 	done := make(chan *Call, 1)
 	call := newCall(ctx, dest, svcName, svcMethod, args, reply, done)
 	go c.makeCall(call)
@@ -78,12 +78,15 @@ func (c *Client) CallWithContext(ctx context.Context, dest peer.ID, svcName, svc
 // attempt to use the local configured Server when possible.
 func (c *Client) Go(dest peer.ID, svcName, svcMethod string, args, reply interface{}, done chan *Call) error {
 	ctx := context.Background()
-	return c.GoWithContext(ctx, dest, svcName, svcMethod, args, reply, done)
+	return c.GoContext(ctx, dest, svcName, svcMethod, args, reply, done)
 }
 
-// GoWithContext performs a Go() call with the provided context, allowing
-// the user to cancel the operation.
-func (c *Client) GoWithContext(ctx context.Context, dest peer.ID, svcName, svcMethod string, args, reply interface{}, done chan *Call) error {
+// GoContext performs a Go() call with the provided context, allowing
+// the user to cancel the operation. See Go() documentation for more information.
+//
+// The provided done channel must be nil, or have capacity for 1 element
+// at least, or a panic will be triggered.
+func (c *Client) GoContext(ctx context.Context, dest peer.ID, svcName, svcMethod string, args, reply interface{}, done chan *Call) error {
 	if done == nil {
 		done = make(chan *Call, 1)
 	} else {

--- a/client.go
+++ b/client.go
@@ -137,10 +137,10 @@ func (c *Client) makeCall(call *Call) {
 // destination and waiting for a response.
 func (c *Client) send(call *Call) {
 	logger.Debug("sending remote call")
+
 	s, err := c.host.NewStream(call.ctx, call.Dest, c.protocol)
 	if err != nil {
-		call.Error = err
-		call.Done <- call
+		call.doneWithError(err)
 		return
 	}
 	defer s.Close()

--- a/server.go
+++ b/server.go
@@ -1,6 +1,6 @@
 /*
-Package rpc is heavily inspired by Go standard net/rpc package. It aims to do
-the same function, except it uses Libp2p for communication and provides
+Package rpc is heavily inspired by Go standard net/rpc package. It aims to
+do the same thing, except it uses Libp2p for communication and provides
 context support for cancelling operations.
 
 A server registers an object, making it visible as a service with the name of

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 /*
 Package rpc is heavily inspired by Go standard net/rpc package. It aims to do
-the same function, except it uses Libp2p for communication.
+the same function, except it uses Libp2p for communication and provides
+context support for cancelling operations.
 
 A server registers an object, making it visible as a service with the name of
 the type of the object.  After registration, exported methods of the object
@@ -12,13 +13,15 @@ Only methods that satisfy these criteria will be made available for remote
 access; other methods will be ignored:
 	- the method's type is exported.
 	- the method is exported.
-	- the method has two arguments, both exported (or builtin) types.
+	- the method has 3 arguments.
+	- the method's first argument is a context.
+	- the method's second are third arguments are both exported (or builtin) types.
 	- the method's second argument is a pointer.
 	- the method has return type error.
 
 In effect, the method must look schematically like
 
-	func (t *T) MethodName(argType T1, replyType *T2) error
+	func (t *T) MethodName(ctx context.Context, argType T1, replyType *T2) error
 
 where T1 and T2 can be marshaled by encoding/gob.
 
@@ -26,17 +29,25 @@ The method's first argument represents the arguments provided by the caller;
 the second argument represents the result parameters to be returned to the
 caller.  The method's return value, if non-nil, is passed back as a string
 that the client sees as if created by errors.New.  If an error is returned,
-the reply parameter will not be sent back to the client.
+the reply parameter may not be sent back to the client.
 
 In order to use this package, a ready-to-go LibP2P Host must be provided
 to clients and servers, along with a protocol.ID. rpc will add a stream
 handler for the given protocol. Hosts must be ready to speak to clients,
 that is, peers must be part of the peerstore along with keys if secio
 communication is required.
+
+Since version 2.0.0, contexts are supported and honored. On the server side,
+methods must take a context. A closure or reset of the libp2p stream will
+trigger a cancellation of the context received by the functions.
+On the client side, the user can optionally provide a context.
+Cancelling the client's context will cancel the operation both on the
+client and on the server side (by closing the associated stream).
 */
 package rpc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -121,6 +132,7 @@ func NewServer(h host.Host, p protocol.ID) *Server {
 				sendResponse(sWrap, resp, nil)
 			}
 		})
+
 	}
 	return s
 }
@@ -168,15 +180,36 @@ func (server *Server) handle(s *streamWrap) error {
 
 	replyv = reflect.New(mtype.ReplyType.Elem())
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctxv := reflect.ValueOf(ctx)
+
+	// This is a connection watchdog. We do not
+	// need to read from this stream anymore.
+	// However we'd like to know if the other side is closed
+	// (or reset). In that case, we need to cancel our
+	// context. Note this will also happen at the end
+	// of a successful operation when we close the stream
+	// on our side.
+	go func() {
+		p := make([]byte, 1)
+		_, err := s.stream.Read(p)
+		if err != nil {
+			cancel()
+		}
+	}()
+
 	// Call service and respond
-	return service.svcCall(s, mtype, svcID, argv, replyv)
+	return service.svcCall(s, mtype, svcID, ctxv, argv, replyv)
 }
 
 // svcCall calls the actual method associated
-func (s *service) svcCall(sWrap *streamWrap, mtype *methodType, svcID ServiceID, argv, replyv reflect.Value) error {
+func (s *service) svcCall(sWrap *streamWrap, mtype *methodType, svcID ServiceID, ctxv, argv, replyv reflect.Value) error {
 	function := mtype.method.Func
+
 	// Invoke the method, providing a new value for the reply.
-	returnValues := function.Call([]reflect.Value{s.rcvr, argv, replyv})
+	returnValues := function.Call([]reflect.Value{s.rcvr, ctxv, argv, replyv})
 	// The return value for the method is an error.
 	errInter := returnValues[0].Interface()
 	errmsg := ""
@@ -215,6 +248,9 @@ func (server *Server) Call(call *Call) error {
 		return err
 	}
 
+	// Use the context value from the call directly
+	ctxv := reflect.ValueOf(call.ctx)
+
 	// Decode the argument value.
 	argIsValue := false // if true, need to indirect before calling.
 	if mtype.ArgType.Kind() == reflect.Ptr {
@@ -248,8 +284,9 @@ func (server *Server) Call(call *Call) error {
 	// Invoke the method, providing a new value for the reply.
 	returnValues := function.Call([]reflect.Value{
 		service.rcvr,
-		argv,
-		replyv})
+		ctxv,    // context
+		argv,    // argument
+		replyv}) // reply
 
 	creplyv := reflect.ValueOf(call.Reply)
 	creplyv.Elem().Set(replyv.Elem())
@@ -379,23 +416,34 @@ func suitableMethods(typ reflect.Type, reportErr bool) map[string]*methodType {
 		if method.PkgPath != "" {
 			continue
 		}
-		// Method needs three ins: receiver, *args, *reply.
-		if mtype.NumIn() != 3 {
+		// Method needs four ins: receiver, context.Context, *args, *reply.
+		if mtype.NumIn() != 4 {
 			if reportErr {
 				log.Println("method", mname, "has wrong number of ins:", mtype.NumIn())
 			}
 			continue
 		}
-		// First arg need not be a pointer.
-		argType := mtype.In(1)
+
+		// First argument needs to be a context
+		ctxType := mtype.In(1)
+		ctxIntType := reflect.TypeOf((*context.Context)(nil)).Elem()
+		if !ctxType.Implements(ctxIntType) {
+			if reportErr {
+				log.Println(mname, "first argument is not a context.Context:", ctxType)
+			}
+			continue
+		}
+
+		// Second arg need not be a pointer so that's not checked.
+		argType := mtype.In(2)
 		if !isExportedOrBuiltinType(argType) {
 			if reportErr {
 				log.Println(mname, "argument type not exported:", argType)
 			}
 			continue
 		}
-		// Second arg must be a pointer.
-		replyType := mtype.In(2)
+		// Third arg must be a pointer.
+		replyType := mtype.In(3)
 		if replyType.Kind() != reflect.Ptr {
 			if reportErr {
 				log.Println("method", mname, "reply type not a pointer:", replyType)

--- a/server_test.go
+++ b/server_test.go
@@ -243,7 +243,7 @@ func TestErrorResponse(t *testing.T) {
 	}
 }
 
-func TestCallWithContextLocal(t *testing.T) {
+func TestCallContextLocal(t *testing.T) {
 	h1, h2 := makeRandomNodes()
 	defer h1.Close()
 	defer h2.Close()
@@ -255,7 +255,7 @@ func TestCallWithContextLocal(t *testing.T) {
 	// Local
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second/2)
 	defer cancel()
-	err := c.CallWithContext(ctx, h2.ID(), "Arith", "Sleep", 5, &struct{}{})
+	err := c.CallContext(ctx, h2.ID(), "Arith", "Sleep", 5, &struct{}{})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -271,7 +271,7 @@ func TestCallWithContextLocal(t *testing.T) {
 	}
 }
 
-func TestCallWithContextRemote(t *testing.T) {
+func TestCallContextRemote(t *testing.T) {
 	h1, h2 := makeRandomNodes()
 	defer h1.Close()
 	defer h2.Close()
@@ -283,7 +283,7 @@ func TestCallWithContextRemote(t *testing.T) {
 	// Local
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err := c.CallWithContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{})
+	err := c.CallContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -299,7 +299,7 @@ func TestCallWithContextRemote(t *testing.T) {
 	}
 }
 
-func TestGoWithContext(t *testing.T) {
+func TestGoContext(t *testing.T) {
 	h1, h2 := makeRandomNodes()
 	defer h1.Close()
 	defer h2.Close()
@@ -312,7 +312,7 @@ func TestGoWithContext(t *testing.T) {
 	defer cancel()
 
 	done := make(chan *Call, 1)
-	err := c.GoWithContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{}, done)
+	err := c.GoContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{}, done)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -154,50 +154,9 @@ func TestRegister(t *testing.T) {
 
 }
 
-func TestRemote(t *testing.T) {
-	h1, h2 := makeRandomNodes()
-	defer h1.Close()
-	defer h2.Close()
-	s := NewServer(h1, "rpc")
-	c := NewClientWithServer(h2, "rpc", s)
-	var arith Arith
-	s.Register(&arith)
-
-	var r int
-	err := c.Call(h1.ID(), "Arith", "Multiply", &Args{2, 3}, &r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r != 6 {
-		t.Error("result is:", r)
-	}
-
-	var a int
-	err = c.Call(h1.ID(), "Arith", "Add", Args{2, 3}, &a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if a != 5 {
-		t.Error("result is:", a)
-	}
-
-	var q Quotient
-	err = c.Call(h1.ID(), "Arith", "Divide", &Args{20, 6}, &q)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if q.Quo != 3 || q.Rem != 2 {
-		t.Error("bad division")
-	}
-}
-
-func TestLocal(t *testing.T) {
-	h1, h2 := makeRandomNodes()
-	defer h1.Close()
-	defer h2.Close()
-
-	s := NewServer(h1, "rpc")
-	c := NewClientWithServer(h1, "rpc", s)
+func testCall(t *testing.T, servNode, clientNode host.Host, dest peer.ID) {
+	s := NewServer(servNode, "rpc")
+	c := NewClientWithServer(clientNode, "rpc", s)
 	var arith Arith
 	s.Register(&arith)
 
@@ -220,13 +179,26 @@ func TestLocal(t *testing.T) {
 	}
 
 	var q Quotient
-	err = c.Call(h1.ID(), "Arith", "Divide", &Args{20, 6}, &q)
+	err = c.Call(dest, "Arith", "Divide", &Args{20, 6}, &q)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if q.Quo != 3 || q.Rem != 2 {
 		t.Error("bad division")
 	}
+}
+
+func TestCall(t *testing.T) {
+	h1, h2 := makeRandomNodes()
+	defer h1.Close()
+	defer h2.Close()
+
+	t.Run("local", func(t *testing.T) {
+		testCall(t, h1, h2, "")
+	})
+	t.Run("remote", func(t *testing.T) {
+		testCall(t, h1, h2, h1.ID())
+	})
 }
 
 func TestErrorResponse(t *testing.T) {
@@ -260,46 +232,17 @@ func TestErrorResponse(t *testing.T) {
 	}
 }
 
-func TestCallContextLocal(t *testing.T) {
-	h1, h2 := makeRandomNodes()
-	defer h1.Close()
-	defer h2.Close()
-	s := NewServer(h1, "rpc")
-	c := NewClientWithServer(h2, "rpc", s)
+func testCallContext(t *testing.T, servHost, clientHost host.Host, dest peer.ID) {
+	s := NewServer(servHost, "rpc")
+	c := NewClientWithServer(clientHost, "rpc", s)
+
 	var arith Arith
 	arith.ctxTracker = &ctxTracker{}
 	s.Register(&arith)
 
-	// Local
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second/2)
 	defer cancel()
-	err := c.CallContext(ctx, h2.ID(), "Arith", "Sleep", 5, &struct{}{})
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-
-	if !strings.Contains(err.Error(), "context") {
-		t.Error("expected a context error:", err)
-	}
-
-	if !arith.ctxTracker.cancelled() {
-		t.Error("expected ctx cancellation in the function")
-	}
-}
-
-func TestCallContextRemote(t *testing.T) {
-	h1, h2 := makeRandomNodes()
-	defer h1.Close()
-	defer h2.Close()
-	s := NewServer(h1, "rpc")
-	c := NewClient(h2, "rpc")
-	var arith Arith
-	arith.ctxTracker = &ctxTracker{}
-	s.Register(&arith)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	err := c.CallContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{})
+	err := c.CallContext(ctx, dest, "Arith", "Sleep", 5, &struct{}{})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -315,27 +258,39 @@ func TestCallContextRemote(t *testing.T) {
 	}
 }
 
-func TestGoContext(t *testing.T) {
+func TestCallContext(t *testing.T) {
 	h1, h2 := makeRandomNodes()
 	defer h1.Close()
 	defer h2.Close()
-	s := NewServer(h1, "rpc")
-	c := NewClientWithServer(h2, "rpc", s)
-	var arith Arith
-	arith.ctxTracker = &ctxTracker{}
-	s.Register(&arith)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second/2)
-	defer cancel()
+	t.Run("local", func(t *testing.T) {
+		testCallContext(t, h1, h2, h2.ID())
+	})
 
-	done := make(chan *Call, 1)
-	err := c.GoContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{}, done)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("remote", func(t *testing.T) {
+		testCallContext(t, h1, h2, h1.ID())
+	})
 
-	call := <-done
-	if call.Error == nil || !strings.Contains(call.Error.Error(), "context") {
-		t.Error("expected a context error:", err)
-	}
+	t.Run("async", func(t *testing.T) {
+		s := NewServer(h1, "rpc")
+		c := NewClientWithServer(h2, "rpc", s)
+
+		var arith Arith
+		arith.ctxTracker = &ctxTracker{}
+		s.Register(&arith)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second/2)
+		defer cancel()
+
+		done := make(chan *Call, 1)
+		err := c.GoContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{}, done)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		call := <-done
+		if call.Error == nil || !strings.Contains(call.Error.Error(), "context") {
+			t.Error("expected a context error:", err)
+		}
+	})
 }

--- a/server_test.go
+++ b/server_test.go
@@ -282,8 +282,6 @@ func TestCallContextLocal(t *testing.T) {
 		t.Error("expected a context error:", err)
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	if !arith.ctxTracker.cancelled() {
 		t.Error("expected ctx cancellation in the function")
 	}
@@ -299,7 +297,6 @@ func TestCallContextRemote(t *testing.T) {
 	arith.ctxTracker = &ctxTracker{}
 	s.Register(&arith)
 
-	// Local
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	err := c.CallContext(ctx, h1.ID(), "Arith", "Sleep", 5, &struct{}{})


### PR DESCRIPTION
Changes to Client:

    The user can now initiate a call with CallWithContext() or GoWithContext(),
    providing a context. Upon context cancellation, the call will be immediately
    terminated and return to the user, setting the error correctly from the
    cancelled context.

Changes to Server:

    This makes server calls to RPC methods context-aware.
    
    In the case of regular RPC-via-libp2p calls, a context is
    created and associated to the incoming stream. If the stream
    is closed or reset, the context will be cancelled. It is
    up to the method's implemented to decide what to do with that.
    
    In the case of RPC-shortcut for local calls, the context optionally
    provided by the client is used directly.

This means that all receiver methods exposed through RPC need to have a `context.Context` as their first argument.

How this affects cluster:

This change will allow cluster to cancel/timeout ongoing operations correctly. Right now there is no way to cancel an ongoing pin without restarting the ipfs daemon and triggering a request error that forces the method to return.