### PR TITLE
add ability to distinguish rpc errors

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.13: Qmb8tTGhxUEcevnFMmuoRHkJb1GzmQ64umAorJvMvqYcPG
+1.0.14: QmPJDfZi6RwNNrxvnnyrCZjDY5F9DnRCJ9FAqUSstyjMoU

--- a/call.go
+++ b/call.go
@@ -26,7 +26,6 @@ type Call struct {
 
 	errorMu sync.Mutex
 	Error   error // After completion, the error status.
-
 }
 
 func newCall(ctx context.Context, dest peer.ID, svcName, svcMethod string, args interface{}, reply interface{}, done chan *Call) *Call {

--- a/call.go
+++ b/call.go
@@ -79,10 +79,11 @@ func (call *Call) watchContextWithStream(s inet.Stream) {
 	case <-call.ctx.Done():
 		if !call.isFinished() { // context was cancelled not by us
 			logger.Debug("call context is done before finishing")
-			// Close() instead of Reset(). This lets the other
+			// FullClose() instead of Reset(). This lets the other
 			// write to the stream without printing errors to
-			// the console (graceful fail).
-			inet.FullClose(s)
+			// the console (graceful fail) and eventually will
+			// reset.
+			go inet.FullClose(s)
 			call.doneWithError(call.ctx.Err())
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -307,14 +307,14 @@ func (c *Client) send(call *Call) {
 // receiveResponse reads a response to an RPC call
 func receiveResponse(s *streamWrap, call *Call) error {
 	logger.Debugf(
-    "waiting response for %s.%s to %s",
-    call.SvcID.Name,
+		"waiting response for %s.%s to %s",
+		call.SvcID.Name,
 		call.SvcID.Method,
-    call.Dest,
-  )
+		call.Dest,
+	)
 	var resp Response
 	if err := s.dec.Decode(&resp); err != nil {
-    call.doneWithError(newClientError(err))
+		call.doneWithError(newClientError(err))
 		return err
 	}
 
@@ -326,7 +326,7 @@ func receiveResponse(s *streamWrap, call *Call) error {
 	// Even on error we sent the reply so it needs to be
 	// read
 	if err := s.dec.Decode(call.Reply); err != nil && err != io.EOF {
-    call.setError(newClientError(err))
+		call.setError(newClientError(err))
 		return err
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -240,7 +240,7 @@ func (c *Client) makeCall(call *Call) {
 			call.SvcID.Method,
 		)
 		if c.server == nil {
-			err := &ClientError{"Cannot make local calls: server not set"}
+			err := &clientError{"Cannot make local calls: server not set"}
 			call.doneWithError(err)
 			return
 		}
@@ -266,7 +266,7 @@ func (c *Client) send(call *Call) {
 
 	s, err := c.host.NewStream(call.ctx, call.Dest, c.protocol)
 	if err != nil {
-		call.doneWithError(NewClientError(err))
+		call.doneWithError(newClientError(err))
 		return
 	}
 	defer s.Close()
@@ -281,18 +281,18 @@ func (c *Client) send(call *Call) {
 		call.Dest,
 	)
 	if err := sWrap.enc.Encode(call.SvcID); err != nil {
-		call.doneWithError(NewClientError(err))
+		call.doneWithError(newClientError(err))
 		s.Reset()
 		return
 	}
 	if err := sWrap.enc.Encode(call.Args); err != nil {
-		call.doneWithError(NewClientError(err))
+		call.doneWithError(newClientError(err))
 		s.Reset()
 		return
 	}
 
 	if err := sWrap.w.Flush(); err != nil {
-		call.doneWithError(NewClientError(err))
+		call.doneWithError(newClientError(err))
 		s.Reset()
 		return
 	}
@@ -309,20 +309,20 @@ func receiveResponse(s *streamWrap, call *Call) {
 	)
 	var resp Response
 	if err := s.dec.Decode(&resp); err != nil {
-		call.doneWithError(NewClientError(err))
+		call.doneWithError(newClientError(err))
 		s.stream.Reset()
 		return
 	}
 
 	defer call.done()
 	if e := resp.Error; e != "" {
-		call.setError(ResponseError(resp.ErrType, e))
+		call.setError(responseError(resp.ErrType, e))
 	}
 
 	// Even on error we sent the reply so it needs to be
 	// read
 	if err := s.dec.Decode(call.Reply); err != nil && err != io.EOF {
-		call.setError(NewClientError(err))
+		call.setError(newClientError(err))
 	}
 	return
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,84 @@
+package rpc
+
+import "errors"
+
+// ResponseErr is an enum type for providing error type
+// information over the wire between rpc server and client.
+type ResponseErr int
+
+const (
+	// NonRPCErr is an error that hasn't arisen from the gorpc package.
+	NonRPCErr ResponseErr = iota
+	// ServerErr is an error that has arisen on the server side.
+	ServerErr
+	// ClientErr is an error that has arisen on the client side.
+	ClientErr
+)
+
+// ServerError indicates that error originated in server
+// specific code.
+type ServerError struct {
+	msg string
+}
+
+func (s *ServerError) Error() string {
+	return s.msg
+}
+
+// NewServerError wraps an error in the ServerError type.
+func NewServerError(err error) error {
+	return &ServerError{err.Error()}
+}
+
+// ClientError indicates that error originated in client
+// specific code.
+type ClientError struct {
+	msg string
+}
+
+func (c *ClientError) Error() string {
+	return c.msg
+}
+
+// NewClientError wraps an error in the ClientError type.
+func NewClientError(err error) error {
+	return &ClientError{err.Error()}
+}
+
+// ResponseError converts an ResponseErr and error message string
+// into the appropriate error type.
+func ResponseError(errType ResponseErr, errMsg string) error {
+	switch errType {
+	case ServerErr:
+		return &ServerError{errMsg}
+	case ClientErr:
+		return &ClientError{errMsg}
+	default:
+		return errors.New(errMsg)
+	}
+}
+
+// ResponseErrorType determines whether an error is of either
+// ServerError or ClientError type and returns the appropriate
+// ResponseErr value.
+func ResponseErrorType(err error) ResponseErr {
+	switch err.(type) {
+	case *ServerError:
+		return ServerErr
+	case *ClientError:
+		return ClientErr
+	default:
+		return NonRPCErr
+	}
+}
+
+// IsRPCError returns whether an error is either a ServerError
+// or ClientError.
+func IsRPCError(err error) bool {
+	switch err.(type) {
+	case *ServerError, *ClientError:
+		return true
+	default:
+		return false
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -2,83 +2,93 @@ package rpc
 
 import "errors"
 
-// ResponseErr is an enum type for providing error type
+// responseErr is an enum type for providing error type
 // information over the wire between rpc server and client.
-type ResponseErr int
+type responseErr int
 
 const (
-	// NonRPCErr is an error that hasn't arisen from the gorpc package.
-	NonRPCErr ResponseErr = iota
-	// ServerErr is an error that has arisen on the server side.
-	ServerErr
-	// ClientErr is an error that has arisen on the client side.
-	ClientErr
+	// nonRPCErr is an error that hasn't arisen from the gorpc package.
+	nonRPCErr responseErr = iota
+	// serverErr is an error that has arisen on the server side.
+	serverErr
+	// clientErr is an error that has arisen on the client side.
+	clientErr
 )
 
-// ServerError indicates that error originated in server
+// serverError indicates that error originated in server
 // specific code.
-type ServerError struct {
+type serverError struct {
 	msg string
 }
 
-func (s *ServerError) Error() string {
+func (s *serverError) Error() string {
 	return s.msg
 }
 
-// NewServerError wraps an error in the ServerError type.
-func NewServerError(err error) error {
-	return &ServerError{err.Error()}
+// newServerError wraps an error in the serverError type.
+func newServerError(err error) error {
+	return &serverError{err.Error()}
 }
 
-// ClientError indicates that error originated in client
+// clientError indicates that error originated in client
 // specific code.
-type ClientError struct {
+type clientError struct {
 	msg string
 }
 
-func (c *ClientError) Error() string {
+func (c *clientError) Error() string {
 	return c.msg
 }
 
-// NewClientError wraps an error in the ClientError type.
-func NewClientError(err error) error {
-	return &ClientError{err.Error()}
+// newClientError wraps an error in the clientError type.
+func newClientError(err error) error {
+	return &clientError{err.Error()}
 }
 
-// ResponseError converts an ResponseErr and error message string
+// responseError converts an responseErr and error message string
 // into the appropriate error type.
-func ResponseError(errType ResponseErr, errMsg string) error {
+func responseError(errType responseErr, errMsg string) error {
 	switch errType {
-	case ServerErr:
-		return &ServerError{errMsg}
-	case ClientErr:
-		return &ClientError{errMsg}
+	case serverErr:
+		return &serverError{errMsg}
+	case clientErr:
+		return &clientError{errMsg}
 	default:
 		return errors.New(errMsg)
 	}
 }
 
-// ResponseErrorType determines whether an error is of either
-// ServerError or ClientError type and returns the appropriate
-// ResponseErr value.
-func ResponseErrorType(err error) ResponseErr {
+// responseErrorType determines whether an error is of either
+// serverError or clientError type and returns the appropriate
+// responseErr value.
+func responseErrorType(err error) responseErr {
 	switch err.(type) {
-	case *ServerError:
-		return ServerErr
-	case *ClientError:
-		return ClientErr
+	case *serverError:
+		return serverErr
+	case *clientError:
+		return clientErr
 	default:
-		return NonRPCErr
+		return nonRPCErr
 	}
 }
 
-// IsRPCError returns whether an error is either a ServerError
-// or ClientError.
+// IsRPCError returns whether an error is either a serverError
+// or clientError.
 func IsRPCError(err error) bool {
 	switch err.(type) {
-	case *ServerError, *ClientError:
+	case *serverError, *clientError:
 		return true
 	default:
 		return false
 	}
+}
+
+// IsServerError returns whether an error is serverError.
+func IsServerError(err error) bool {
+	return responseErrorType(err) == serverErr
+}
+
+// IsClientError returns whether an error is clientError.
+func IsClientError(err error) bool {
+	return responseErrorType(err) == clientErr
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT/BSD",
   "name": "go-libp2p-gorpc",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.13"
+  "version": "1.0.14"
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -210,26 +210,87 @@ func TestErrorResponse(t *testing.T) {
 	var arith Arith
 	s.Register(&arith)
 
-	var r int
-	// test remote
-	c := NewClientWithServer(h2, "rpc", s)
-	err := c.Call(h1.ID(), "Arith", "GimmeError", &Args{1, 2}, &r)
-	if err == nil || err.Error() != "an error" {
-		t.Error("expected different error")
-	}
-	if r != 42 {
-		t.Error("response should be set even on error")
-	}
+	t.Run("remote", func(t *testing.T) {
+		var r int
+		c := NewClientWithServer(h2, "rpc", s)
+		err := c.Call(h1.ID(), "Arith", "GimmeError", &Args{1, 2}, &r)
+		if err == nil || err.Error() != "an error" {
+			t.Error("expected different error")
+		}
+		if r != 42 {
+			t.Error("response should be set even on error")
+		}
+	})
 
-	// test local
-	c = NewClientWithServer(h1, "rpc", s)
-	err = c.Call(h1.ID(), "Arith", "GimmeError", &Args{1, 2}, &r)
-	if err == nil || err.Error() != "an error" {
-		t.Error("expected different error")
-	}
-	if r != 42 {
-		t.Error("response should be set even on error")
-	}
+	t.Run("local", func(t *testing.T) {
+		var r int
+		c := NewClientWithServer(h1, "rpc", s)
+		err := c.Call(h1.ID(), "Arith", "GimmeError", &Args{1, 2}, &r)
+		if err == nil || err.Error() != "an error" {
+			t.Error("expected different error")
+		}
+		if r != 42 {
+			t.Error("response should be set even on error")
+		}
+	})
+}
+
+func TestNonRPCError(t *testing.T) {
+	h1, h2 := makeRandomNodes()
+	defer h1.Close()
+	defer h2.Close()
+
+	s := NewServer(h1, "rpc")
+	var arith Arith
+	s.Register(&arith)
+
+	t.Run("local non rpc error", func(t *testing.T) {
+		var r int
+		c := NewClientWithServer(h1, "rpc", s)
+		err := c.Call(h1.ID(), "Arith", "GimmeError", &Args{1, 2}, &r)
+		if err != nil {
+			if IsRPCError(err) {
+				t.Log(err)
+				t.Error("expected non rpc error")
+			}
+		}
+	})
+
+	t.Run("local rpc error", func(t *testing.T) {
+		var r int
+		c := NewClientWithServer(h1, "rpc", s)
+		err := c.Call(h1.ID(), "Arith", "ThisIsNotAMethod", &Args{1, 2}, &r)
+		if err != nil {
+			if !IsRPCError(err) {
+				t.Log(err)
+				t.Error("expected rpc error")
+			}
+		}
+	})
+
+	t.Run("remote non rpc error", func(t *testing.T) {
+		var r int
+		c := NewClientWithServer(h2, "rpc", s)
+		err := c.Call(h1.ID(), "Arith", "GimmeError", &Args{1, 2}, &r)
+		if err != nil {
+			if IsRPCError(err) {
+				t.Log(err)
+				t.Error("expected non rpc error")
+			}
+		}
+	})
+
+	t.Run("remote rpc error", func(t *testing.T) {
+		var r int
+		c := NewClientWithServer(h2, "rpc", s)
+		err := c.Call(h1.ID(), "Arith", "ThisIsNotAMethod", &Args{1, 2}, &r)
+		if err != nil {
+			if !IsRPCError(err) {
+				t.Log(err)
+				t.Error("expected rpc error")
+			}
+		}
+	})
 }
 
 func testCallContext(t *testing.T, servHost, clientHost host.Host, dest peer.ID) {


### PR DESCRIPTION
This allows for users of the package to determine whether
a returned error is from the gorpc package or their code.